### PR TITLE
Add container-based patching

### DIFF
--- a/HaroohieClub.NitroPacker.Cli/HaroohieClub.NitroPacker.Cli.csproj
+++ b/HaroohieClub.NitroPacker.Cli/HaroohieClub.NitroPacker.Cli.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <AssemblyName>NitroPacker</AssemblyName>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HaroohieClub.NitroPacker.Cli/PatchArm9Command.cs
+++ b/HaroohieClub.NitroPacker.Cli/PatchArm9Command.cs
@@ -12,6 +12,7 @@ namespace HaroohieClub.NitroPacker.Cli
     {
         private string _inputDir, _outputDir;
         private uint _arenaLoOffset;
+        private bool _useDocker;
 
         public PatchArm9Command() : base("patch-arm9", "Patches the game's arm9.bin")
         {
@@ -20,6 +21,7 @@ namespace HaroohieClub.NitroPacker.Cli
                 { "i|input-dir=", "Input directory containing arm9.bin and source", i => _inputDir = i },
                 { "o|output-dir=", "Output directory for writing modified arm9.bin", o => _outputDir = o },
                 { "a|arena-lo-offset=", "ArenaLoOffset provided as a hex number", a => _arenaLoOffset = uint.Parse(a, NumberStyles.HexNumber) },
+                { "d|use-docker", "Use docker to build rather than make directly", d => _useDocker = true },
             };
         }
 
@@ -46,7 +48,7 @@ namespace HaroohieClub.NitroPacker.Cli
             }
 
             ARM9 arm9 = new(File.ReadAllBytes(Path.Combine(_inputDir, "arm9.bin")), 0x02000000);
-            if (!ARM9AsmHack.Insert(_inputDir, arm9, _arenaLoOffset,
+            if (!ARM9AsmHack.Insert(_inputDir, arm9, _arenaLoOffset, _useDocker,
                 (object sender, DataReceivedEventArgs e) => Console.WriteLine(e.Data),
                 (object sender, DataReceivedEventArgs e) => Console.Error.WriteLine(e.Data)))
             {

--- a/HaroohieClub.NitroPacker.Cli/PatchArm9Command.cs
+++ b/HaroohieClub.NitroPacker.Cli/PatchArm9Command.cs
@@ -10,9 +10,8 @@ namespace HaroohieClub.NitroPacker.Cli
 {
     public class PatchArm9Command : Command
     {
-        private string _inputDir, _outputDir;
+        private string _inputDir, _outputDir, _dockerTag;
         private uint _arenaLoOffset;
-        private bool _useDocker;
 
         public PatchArm9Command() : base("patch-arm9", "Patches the game's arm9.bin")
         {
@@ -21,7 +20,7 @@ namespace HaroohieClub.NitroPacker.Cli
                 { "i|input-dir=", "Input directory containing arm9.bin and source", i => _inputDir = i },
                 { "o|output-dir=", "Output directory for writing modified arm9.bin", o => _outputDir = o },
                 { "a|arena-lo-offset=", "ArenaLoOffset provided as a hex number", a => _arenaLoOffset = uint.Parse(a, NumberStyles.HexNumber) },
-                { "d|use-docker", "Use docker to build rather than make directly", d => _useDocker = true },
+                { "d|docker-tag=", "Indicates docker should be used and provides a docker tag of the devkitpro/devkitarm image to use", d => _dockerTag = d },
             };
         }
 
@@ -48,7 +47,7 @@ namespace HaroohieClub.NitroPacker.Cli
             }
 
             ARM9 arm9 = new(File.ReadAllBytes(Path.Combine(_inputDir, "arm9.bin")), 0x02000000);
-            if (!ARM9AsmHack.Insert(_inputDir, arm9, _arenaLoOffset, _useDocker,
+            if (!ARM9AsmHack.Insert(_inputDir, arm9, _arenaLoOffset, _dockerTag,
                 (object sender, DataReceivedEventArgs e) => Console.WriteLine(e.Data),
                 (object sender, DataReceivedEventArgs e) => Console.Error.WriteLine(e.Data)))
             {

--- a/HaroohieClub.NitroPacker.Cli/PatchOverlaysCommand.cs
+++ b/HaroohieClub.NitroPacker.Cli/PatchOverlaysCommand.cs
@@ -10,8 +10,8 @@ namespace HaroohieClub.NitroPacker.Cli
 {
     public class PatchOverlaysCommand : Command
     {
-        private string _inputOverlaysDirectory, _outputOverlaysDirectory, _overlaySourceDir, _romInfoPath;
-        private bool _useDocker, _showHelp;
+        private string _inputOverlaysDirectory, _outputOverlaysDirectory, _overlaySourceDir, _romInfoPath, _dockerTag;
+        private bool _showHelp;
 
         public PatchOverlaysCommand() : base("patch-overlays", "Patches the game's overlays")
         {
@@ -24,7 +24,7 @@ namespace HaroohieClub.NitroPacker.Cli
                 { "o|output-overlays=", "Directory where patched overlays will be written", o => _outputOverlaysDirectory = o },
                 { "s|source-dir=", "Directory where overlay source code lives", s => _overlaySourceDir = s },
                 { "r|rom-info=", "rominfo.xml file containing the overlay table", r => _romInfoPath = r },
-                { "d|use-docker", "Use docker to build rather than make directly", d => _useDocker = true },
+                { "d|docker-tag=", "Indicates docker should be used and provides a docker tag of the devkitpro/devkitarm image to use", d => _dockerTag = d },
                 { "h|help", "Shows this help screen", h => _showHelp = true },
             };
         }
@@ -75,7 +75,7 @@ namespace HaroohieClub.NitroPacker.Cli
             {
                 if (Directory.GetDirectories(_overlaySourceDir).Contains(Path.Combine(_overlaySourceDir, overlay.Name)))
                 {
-                    OverlayAsmHack.Insert(_overlaySourceDir, overlay, _romInfoPath, _useDocker,
+                    OverlayAsmHack.Insert(_overlaySourceDir, overlay, _romInfoPath, _dockerTag,
                         (object sender, DataReceivedEventArgs e) => Console.WriteLine(e.Data),
                         (object sender, DataReceivedEventArgs e) => Console.Error.WriteLine(e.Data));
                 }

--- a/HaroohieClub.NitroPacker.Cli/PatchOverlaysCommand.cs
+++ b/HaroohieClub.NitroPacker.Cli/PatchOverlaysCommand.cs
@@ -11,7 +11,7 @@ namespace HaroohieClub.NitroPacker.Cli
     public class PatchOverlaysCommand : Command
     {
         private string _inputOverlaysDirectory, _outputOverlaysDirectory, _overlaySourceDir, _romInfoPath;
-        private bool _showHelp;
+        private bool _useDocker, _showHelp;
 
         public PatchOverlaysCommand() : base("patch-overlays", "Patches the game's overlays")
         {
@@ -24,6 +24,7 @@ namespace HaroohieClub.NitroPacker.Cli
                 { "o|output-overlays=", "Directory where patched overlays will be written", o => _outputOverlaysDirectory = o },
                 { "s|source-dir=", "Directory where overlay source code lives", s => _overlaySourceDir = s },
                 { "r|rom-info=", "rominfo.xml file containing the overlay table", r => _romInfoPath = r },
+                { "d|use-docker", "Use docker to build rather than make directly", d => _useDocker = true },
                 { "h|help", "Shows this help screen", h => _showHelp = true },
             };
         }
@@ -74,7 +75,7 @@ namespace HaroohieClub.NitroPacker.Cli
             {
                 if (Directory.GetDirectories(_overlaySourceDir).Contains(Path.Combine(_overlaySourceDir, overlay.Name)))
                 {
-                    OverlayAsmHack.Insert(_overlaySourceDir, overlay, _romInfoPath,
+                    OverlayAsmHack.Insert(_overlaySourceDir, overlay, _romInfoPath, _useDocker,
                         (object sender, DataReceivedEventArgs e) => Console.WriteLine(e.Data),
                         (object sender, DataReceivedEventArgs e) => Console.Error.WriteLine(e.Data));
                 }

--- a/HaroohieClub.NitroPacker.Cli/Properties/launchSettings.json
+++ b/HaroohieClub.NitroPacker.Cli/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "HaroohieClub.NitroPacker.Cli": {
       "commandName": "Project",
-      "commandLineArgs": "unpack -r unpacked\\data\\data.srl -o unpacked\\data\\matroskya -p MATROSKYA",
-      "workingDirectory": "D:\\ROMHacking\\DSHacking\\test"
+      "commandLineArgs": "patch-arm9 -i ./src -o ./rom -a 02005ECC -d 20221115",
+      "workingDirectory": "C:\\Users\\jonko\\source\\repos\\ChokuretsuTranslationBuild\\"
     }
   }
 }

--- a/HaroohieClub.NitroPacker.Core/HaroohieClub.NitroPacker.Core.csproj
+++ b/HaroohieClub.NitroPacker.Core/HaroohieClub.NitroPacker.Core.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <Title>NitroPacker.Core</Title>
     <Authors>Ermelber, Gericom, Jonko</Authors>
     <Company>Haroohie Translation Club</Company>

--- a/HaroohieClub.NitroPacker.IO/HaroohieClub.NitroPacker.IO.csproj
+++ b/HaroohieClub.NitroPacker.IO/HaroohieClub.NitroPacker.IO.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	<Version>2.1.0</Version>
+	<Version>2.2.0</Version>
 	<Title>NitroPacker.IO</Title>
 	<Authors>Ermelber, Gericom, Jonko</Authors>
 	<Company>Haroohie Translation Club</Company>

--- a/HaroohieClub.NitroPacker.Nitro/HaroohieClub.NitroPacker.Nitro.csproj
+++ b/HaroohieClub.NitroPacker.Nitro/HaroohieClub.NitroPacker.Nitro.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
-	<Version>2.1.0</Version>
+	<Version>2.2.0</Version>
 	<Title>NitroPacker.Nitro</Title>
 	<Authors>Ermelber, Gericom, Jonko</Authors>
 	<Company>Haroohie Translation Club</Company>

--- a/HaroohieClub.NitroPacker.Patcher/HaroohieClub.NitroPacker.Patcher.csproj
+++ b/HaroohieClub.NitroPacker.Patcher/HaroohieClub.NitroPacker.Patcher.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
-	  <Version>2.1.0</Version>
+	  <Version>2.2.0</Version>
 	  <Title>NitroPacker.Patcher</Title>
 	  <Authors>Ermelber, Gericom, Jonko</Authors>
 	  <Company>Haroohie Translation Club</Company>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This code was written primarily by Ermelber and Gericom. Jonko has ported it to 
 
 ## Prerequisites
 * [.NET 6.0 Runtime](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) is required to run the tool.
-* [devkitARM](https://devkitpro.org/wiki/Getting_Started) is required to apply ASM hacks.
+* [devkitARM](https://devkitpro.org/wiki/Getting_Started) and [Make](https://www.gnu.org/software/make/) are required to apply ASM hacks.
+  - Alternatively, one can opt to install [Docker](https://www.docker.com/) (and [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) on Windows)
+    instead.
 
 ## Packing and Unpacking
 The primary purpose of NitroPacker is to pack and unpack NDS ROMs.
@@ -33,7 +35,23 @@ NitroPacker pack -p PATH/TO/PROJECT_FILE.xml -r PATH/TO/OUTPUT_ROM.nds
 The project file is expected to be in a directory with ARM9 and ARM7 binaries as well as the data and overlay subdirectories mentioned previously.
 
 ## ASM Hacks
-NitroPacker can also be used as a powerful tool to apply assembly hacks, but this functionality is a bit more complicated. For one thing, you will need to move the unpacked `arm9.bin` to a different directory with a specific structure.
+NitroPacker can also be used as a powerful tool to apply assembly hacks, but this functionality is a bit more complicated.
+
+### Install Prerequisites
+As mentioned above, NitroPacker relies on other programs to help with the assembling your hacks, namely, devkitARM and Make. DevkitARM is distributed
+by devkitPro and can be downloaded from their website. They have a graphical installer for Windows (for which you need only select the NDS workloads)
+and a package manager for Mac/Linux (for which you can run the command `dkp-pacman -S nds-dev` to install devkitARM).
+
+On Linux distros, Make can be installed from the package manager (e.g. `sudo apt install make`). On macOS, you can use [brew](https://formulae.brew.sh/formula/make). On Windows, the easiest way to install it is with Chocolatey, where the command is `choco install make`.
+
+If either of these options presents a challenge for you or doesn't work for some reason, you can instead opt to use the alternate method of assembling
+the code in Docker containers. After installing [Docker Desktop](https://www.docker.com/products/docker-desktop/) or the Docker engine, ensure the engine
+is running. Then, when calling NitroPacker, ensure you pass `-d` followed by the Docker tag you want to use. If you're not sure which one to use, we
+recommend trying `20230526` as that is the most recent tag as of this publishing (when the samples were last updated). If you want to use newer features
+or need later bugfixes, choose `latest` or a later tag.
+
+### Directory Structure
+You will need to move the unpacked `arm9.bin` to a different directory with a specific structure:
 
 * `src`
   - `overlays`
@@ -98,7 +116,7 @@ Once this directory has been constructed, source files have been created, the ar
 ### Assemble ARM9
 To assemble the hacked ARM9, run the following command:
 ```
-NitroPacker patch-arm9 -i PATH/TO/SRC/DIRECTORY -o PATH/TO/OUTPUT/DIRECTORY -a ARENA_LO_OFFSET
+NitroPacker patch-arm9 -i PATH/TO/SRC/DIRECTORY -o PATH/TO/OUTPUT/DIRECTORY -a ARENA_LO_OFFSET [-d DOCKER_TAG]
 ```
 
 This will assemble the hacks and append them to `arm9.bin`, then copy the ARM9 to the output directory (which should be the directory you will then run
@@ -107,5 +125,5 @@ the `pack` command on).
 ### Assemble Overlays
 To patch the overlays, run the following command:
 ```
-NitroPacker patch-overlays -i PATH/TO/ORIGINAL/OVERLAY/DIRECTORY -o PATH/TO/PATCHED/OVERLAY/DIRECTORY -s PATH/TO/OVERLAY/SOURCE -r PATH/TO/PROJECT/FILE
+NitroPacker patch-overlays -i PATH/TO/ORIGINAL/OVERLAY/DIRECTORY -o PATH/TO/PATCHED/OVERLAY/DIRECTORY -s PATH/TO/OVERLAY/SOURCE -r PATH/TO/PROJECT/FILE [-d DOCKER_TAG]
 ```

--- a/asm_sample/Makefile
+++ b/asm_sample/Makefile
@@ -118,7 +118,7 @@ export INCLUDE	:=	$(foreach dir,$(INCLUDES),-iquote $(CURDIR)/$(dir)) \
 					$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
 					-I$(CURDIR)/$(BUILD)
  
-export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib) -L$(DEVKITARM)/lib/gcc/arm-none-eabi/12.2.0
+export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib) -L$(DEVKITARM)/lib/gcc/arm-none-eabi/13.1.0
 
  
 .PHONY: $(BUILD) clean

--- a/asm_sample/overlays/Makefile
+++ b/asm_sample/overlays/Makefile
@@ -118,7 +118,7 @@ export INCLUDE	:=	$(foreach dir,$(INCLUDES),-iquote $(CURDIR)/$(dir)) \
 					$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
 					-I$(CURDIR)/$(BUILD)
  
-export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib) -L$(DEVKITARM)/lib/gcc/arm-none-eabi/12.2.0
+export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib) -L$(DEVKITARM)/lib/gcc/arm-none-eabi/13.1.0
 
  
 .PHONY: $(BUILD) clean


### PR DESCRIPTION
This adds the ability to specify using Docker instead of installing devkitARM/make when using the patching functionality. It pulls the devkitpro/devkitarm image (with a tag specified by the user) and then execs `docker run` and passes the make command into the container rather than executing make itself.