### PR TITLE
feat: support 0x prefix for arena-lo-offset cli argument

### DIFF
--- a/HaroohieClub.NitroPacker.Cli/PatchArm9Command.cs
+++ b/HaroohieClub.NitroPacker.Cli/PatchArm9Command.cs
@@ -19,7 +19,7 @@ namespace HaroohieClub.NitroPacker.Cli
             {
                 { "i|input-dir=", "Input directory containing arm9.bin and source", i => _inputDir = i },
                 { "o|output-dir=", "Output directory for writing modified arm9.bin", o => _outputDir = o },
-                { "a|arena-lo-offset=", "ArenaLoOffset provided as a hex number", a => _arenaLoOffset = uint.Parse(a, NumberStyles.HexNumber) },
+                { "a|arena-lo-offset=", "ArenaLoOffset provided as a hex number", a => _arenaLoOffset = uint.Parse(a.StartsWith("0x")?a[2..]:a, NumberStyles.HexNumber) },
                 { "d|docker-tag=", "(Optional) Indicates Docker should be used and provides a docker tag of the devkitpro/devkitarm image to use", d => _dockerTag = d },
                 { "devkitarm=", "(Optional) Location of the devkitARM installation; defaults to the DEVKITARM environment variable", dev => _devkitArm = dev },
             };


### PR DESCRIPTION
Love this tool ! Incredible works!

## Description

I am making this small PR to add support to write `--arena-lo-offset=0x????` and `--arena-lo-offset=????` since they are both valid format, and having the `0x` prefix is very common! 