### PR TITLE
Fix File Name Table issue with Shift-JIS file names

### DIFF
--- a/HaroohieClub.NitroPacker/IO/EndianBinaryWriter.cs
+++ b/HaroohieClub.NitroPacker/IO/EndianBinaryWriter.cs
@@ -120,9 +120,9 @@ public class EndianBinaryWriter : IDisposable
         int size;
 
         size = GetEncodingSize(encoding);
-        CreateBuffer(size * count);
-        Array.Copy(encoding.GetBytes(value, offset, count), 0, _buffer, 0, count * size);
-        WriteBuffer(size * count, size);
+        CreateBuffer(count);
+        Array.Copy(encoding.GetBytes(value, offset, value.Length), 0, _buffer, 0, count);
+        WriteBuffer(count, size);
     }
 
     private static int GetEncodingSize(Encoding encoding)
@@ -143,7 +143,7 @@ public class EndianBinaryWriter : IDisposable
     /// <param name="nullTerminated">Whether to null-terminate the string or not</param>
     public void Write(string value, Encoding encoding, bool nullTerminated)
     {
-        Write(value.ToCharArray(), 0, value.Length, encoding);
+        Write(value.ToCharArray(), 0, encoding.GetByteCount(value), encoding);
         if (nullTerminated)
             Write('\0', encoding);
     }

--- a/HaroohieClub.NitroPacker/Nitro/Fs/NameTableEntry.cs
+++ b/HaroohieClub.NitroPacker/Nitro/Fs/NameTableEntry.cs
@@ -59,12 +59,14 @@ public class NameTableEntry
     /// <exception cref="ArgumentException">Thrown if the name is too long or if the directory ID is invalid</exception>
     private NameTableEntry(NameTableEntryType type, string name = null, ushort directoryId = 0)
     {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         Type = type;
         if (type != NameTableEntryType.EndOfDirectory)
         {
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
-            if (name.Length == 0 || name.Length > 0x7F)
+            if (Encoding.GetEncoding("Shift-JIS").GetByteCount(name) == 0 
+                || Encoding.GetEncoding("Shift-JIS").GetByteCount(name) > 0x7F)
                 throw new ArgumentException("Name length invalid", nameof(name));
             Name = name;
         }
@@ -109,22 +111,23 @@ public class NameTableEntry
     public void Write(EndianBinaryWriter er)
     {
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        var ShiftJIS = Encoding.GetEncoding("Shift-JIS");
         switch (Type)
         {
             case NameTableEntryType.EndOfDirectory:
                 er.Write((byte)0);
                 break;
             case NameTableEntryType.File:
-                if (Name.Length > 0x7F)
+                if (ShiftJIS.GetByteCount(Name) > 0x7F)
                     throw new DataException($"File name '{Name}' too long");
-                er.Write((byte)Name.Length);
-                er.Write(Name, Encoding.GetEncoding("Shift-JIS"), false);
+                er.Write((byte)ShiftJIS.GetByteCount(Name));
+                er.Write(Name, ShiftJIS, false);
                 break;
             case NameTableEntryType.Directory:
-                if (Name.Length > 0x7F)
+                if (ShiftJIS.GetByteCount(Name) > 0x7F)
                     throw new DataException($"Directory name '{Name}' too long");
-                er.Write((byte)(Name.Length | 0x80));
-                er.Write(Name, Encoding.GetEncoding("Shift-JIS"), false);
+                er.Write((byte)(ShiftJIS.GetByteCount(Name) | 0x80));
+                er.Write(Name, ShiftJIS, false);
                 er.Write(DirectoryId);
                 break;
             default:


### PR DESCRIPTION
While I was working with a game in which some file names have non-ASCII (Shift-JIS) characters, I discovered that such file names are stripped in the File Name Table. The reason was that when counting the number of characters, a wide character was counted as 1, when it should be 2. I changed as such so that the number of *bytes* is counted.